### PR TITLE
Improve MappingRules to match dynamic actions of custom Rest Controllers

### DIFF
--- a/src/groovy/org/restapidoc/utils/MappingRulesEntry.groovy
+++ b/src/groovy/org/restapidoc/utils/MappingRulesEntry.groovy
@@ -1,42 +1,136 @@
 package org.restapidoc.utils
 
+import groovy.util.logging.Log
+import org.restapidoc.pojo.RestApiParamDoc
+
 /**
  * Created by lrollus on 1/10/14.
  */
+@Log
 class MappingRules {
 
-//    static String FIRSTCHARPATH = "/api"
+    Map<String, List<MappingRulesEntry>> rules = new TreeMap<String, MappingRulesEntry>()
 
-//    static String DEFAULT_FORMAT = "json"
-
-    Map<String, MappingRulesEntry> rules = new TreeMap<String, MappingRulesEntry>()
-
-    public void addRule(String controllerName, String actioName, String path, String verb, String defaultFormat) {
-        String key = (controllerName + "." + actioName).toUpperCase()
-        key = key.replace("CONTROLLER", "")
-
-        String shortPath = path
-//        if(shortPath.startsWith(FIRSTCHARPATH)) {
-//            shortPath = shortPath.substring(FIRSTCHARPATH.size())
-//        }
-        //shortPath = shortPath.replace("{format}",defaultFormat)
-
-        rules.put(key, new MappingRulesEntry(path: shortPath, verb: verb))
+    public void addRule(String controllerName, String actionName, String path, String verb, String defaultFormat = "") {
+        def entries = rules.get(controllerName) ?: new ArrayList<MappingRulesEntry>()
+        entries.push(new MappingRulesEntry(path: path, verb: verb, action: actionName, format: defaultFormat))
+        rules.put(controllerName, entries)
     }
 
-    public MappingRulesEntry getRule(String controllerName, String actionName) {
-        String key = (controllerName + "." + actionName).toUpperCase()
-        key = key.replace("CONTROLLER", "")
-        rules.get(key)
+    /**
+     * Match a mapping rule from grails UrlMappings
+     * @param controller    Controller name to look at
+     * @param action        Controller action to match
+     * @param urlParams     Paths params as declared in UrlMappings and constraints
+     * @param format        Output format (json, xml, ...)
+     * @return
+     */
+    MappingRulesEntry matchRule(String controller, String action, List<RestApiParamDoc> urlParams = [], String format) {
+        MappingRulesEntry matchRule
+        String controllerName = camelUpperCase(controller)
+        log.info("controller: $controllerName / action: $action")
+        List<MappingRulesEntry> entries = rules.get(controllerName)
+        if (!entries) return
+
+        // Find by action
+        matchRule = matchByAction(controllerName, action)
+        if (matchRule) {
+            println "Matched rule by action: " + matchRule
+            return matchRule
+        }
+        else {
+            // Find by URL params
+            matchRule = matchByURLParams(controllerName, urlParams, format)
+            println "Matched rule by URL params: " + matchRule
+        }
+        return matchRule
     }
 
+    /**
+     * Macth mapping rule by controller action
+     * @param controllerName
+     * @param action
+     * @return
+     */
+    private MappingRulesEntry matchByAction(String controllerName, String action) {
+        if (!action) return null
+        return rules.get(controllerName).find { it.action == action }
+    }
+
+    /**
+     * Match mapping rule by path params
+     * @param controllerName
+     * @param urlParams
+     * @param format
+     * @return
+     */
+    private MappingRulesEntry matchByURLParams(String controllerName, List<RestApiParamDoc> urlParams, String format = "") {
+        if (urlParams) {
+            def params = urlParams.collect { it.name }
+            def matches = rules.get(controllerName)?.findAll { matchAllParams(it.path, params) }
+            if (matches) {
+                if (matches.size() > 1) {
+                    // Find out if format has been set
+                    matches = matches.findAll { it.format == format }
+                }
+                return matches[0]
+            }
+            return null
+        }
+    }
+
+    protected String camelUpperCase(String stringToSplit) {
+        if (!stringToSplit) return ""
+        String result = stringToSplit[0].toLowerCase()
+        for (int i = 1; i < stringToSplit.size(); i++) {
+            def car = stringToSplit[i]
+            if (car != car.toUpperCase()) {
+                result = result + car
+            } else {
+                result = result + car.toUpperCase()
+            }
+        }
+
+        return result.trim()
+    }
+
+    /**
+     * Check if rule path match all given params.
+     * Reserved tokens like {action} or {format} are filtered.
+     *
+     * @param path
+     * @param params
+     * @return
+     */
+    protected boolean matchAllParams(String path, List<String> params) {
+        def filtered = ['action', 'format']
+        def pattern = /\{\w*}/
+        def pathParams = (path =~ pattern).findAll { !(param(it) in filtered) }.collect { param(it) }
+        return params.sort() == pathParams.sort()
+    }
+
+    private String param(String tokenParam) {
+        String param = tokenParam.replaceFirst(/\{/, '')
+        param = param.replaceFirst(/}/, '')
+        return param
+    }
+
+    @Override
+    public String toString() {
+        return "MappingRules{" +
+                "rules=" + rules +
+                '}';
+    }
 }
 
 class MappingRulesEntry {
-    public String path
-    public String verb
+
+    String path
+    String verb
+    String action
+    String format
 
     public String toString() {
-        return "path = $path , verb = $verb"
+        return "path = $path , verb = $verb , action = $action , format = $format"
     }
 }

--- a/test/unit/org/restapidoc/utils/MappingRulesSpec.groovy
+++ b/test/unit/org/restapidoc/utils/MappingRulesSpec.groovy
@@ -1,0 +1,92 @@
+package org.restapidoc.utils
+
+import org.restapidoc.pojo.RestApiParamDoc
+import spock.lang.Specification
+
+
+/**
+ * Created by lguerin on 04/06/15.
+ */
+class MappingRulesSpec extends Specification {
+
+    MappingRules mappingRules
+
+    def setup() {
+        mappingRules = new MappingRules()
+    }
+
+    def "Camel upper case controller name"() {
+        expect:
+        expected == mappingRules.camelUpperCase(controller)
+
+        where:
+        controller            | expected
+        "BookController"      | "bookController"
+        "MyBookController"    | "myBookController"
+        ""                    | ""
+    }
+
+    def "Does path match all params"() {
+        expect:
+        match == mappingRules.matchAllParams(path, params)
+
+        where:
+        match | params                  | path
+        true  | ["bookId"]              | "/api/custom/{bookId}/{action}"
+        false | ["bookId", "authorId"]  | "/api/custom/{bookId}/{action}"
+        true  | ["bookId", "authorId"]  | "/api/custom/{bookId}/by/{authorId}/{action}"
+        false | ["bookId"]              | "/api/custom/{bookId}/by/{authorId}/{action}"
+        true  | ["bookId", "authorId"]  | "/api/custom/{bookId}/by/{authorId}/{action}.{format}"
+    }
+
+    def "Match rules by action name"() {
+        given:
+        mappingRules.addRule "bookController", "save", "/api/book.{format}", "POST", "json"
+        mappingRules.addRule "bookController", "show", "/api/book/{id}.{format}", "GET", "json"
+        mappingRules.addRule "bookController", "update", "/api/book/{id}.{format}", "PUT", "json"
+        mappingRules.addRule "bookController", "delete", "/api/book/{id}.{format}", "DELETE", "json"
+        mappingRules.addRule "bookController", "listByAuthor", "/api/author/{id}/book.{format}", "GET", "json"
+
+        expect:
+        path == mappingRules.matchRule(controller, action, "json")?.getPath()
+
+        where:
+        controller                  | action          | path
+        "bookController"            | "show"          | "/api/book/{id}.{format}"
+        "bookController"            | "listByAuthor"  | "/api/author/{id}/book.{format}"
+        "bookController"            | "XXX"           | null
+        "XXX"                       | ""              | null
+    }
+
+    def "Match rules by URL params"() {
+        given:
+        mappingRules.addRule "restCustomController", "", "/api/custom/{bookId}/chapter/{chapterId2}/{action}.{format}", "*", "json"
+        mappingRules.addRule "restCustomController", "", "/api/custom/{bookId}/{action}.{format}", "*", "json"
+        mappingRules.addRule "restCustomController", "", "/api/custom/{bookId}/{action}.{format}", "DELETE", "json"
+        List<RestApiParamDoc> urlParams = []
+        urlParams.add(new RestApiParamDoc(name: "bookId"))
+
+        when:
+        def match = mappingRules.matchRule("restCustomController", "", urlParams, "json")
+
+        then:
+        match != null
+        match.path == "/api/custom/{bookId}/{action}.{format}"
+
+        when: 'We have duplicate paths for the same controller with a different verb'
+        mappingRules.addRule "restCustomController", "", "/api/custom/{bookId}/{action}.{format}", "PUT",  "json"
+        match = mappingRules.matchRule("restCustomController", "", urlParams, "json")
+
+        then: 'Get the first path who match'
+        match != null
+        match.path == "/api/custom/{bookId}/{action}.{format}"
+
+        when: 'We have many paths that match given params for the same controller but with a different format'
+        mappingRules.addRule "restCustomController", "", "/api/custom/xml/{bookId}/{action}.{format}", "PUT",  "xml"
+        match = mappingRules.matchRule("restCustomController", "", urlParams, "xml")
+
+        then: 'Get the path whith the right format'
+        match != null
+        match.path == "/api/custom/xml/{bookId}/{action}.{format}"
+    }
+}


### PR DESCRIPTION
I like your plugin, but I have a lots of use cases where I have to create some REST controllers with custom UrlMappings settings. 
Basically, I declare UrlMappings manually to match my controller actions with constraints and (sometime) grouping features.
In that case, the actual BuildPathMap mechanism is not sufficient to match my custom controller paths and replace the target action dynamically ; and so the generated documentation is not set correctly.
You can have a look at a simple example here : https://github.com/lguerin/Rest-api-doc-example/commit/97e414f150a510178cca926991948f48d2159d81
This pull-request suggest a solution to fix that cases.
Thx.
